### PR TITLE
Add pip check

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,6 +6,12 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
 zip_keys:
 - - cdt_name
   - docker_image

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,19 @@
 {% set name = "python-jose" %}
 {% set version = "3.3.0" %}
 
+
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/python-jose-{{ version }}.tar.gz
   sha256: 55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a
 
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -21,9 +22,11 @@ requirements:
     - pytest-runner
   run:
     - cryptography
-    - future <1.0
     - python >=3.6
-    - six <2.0
+    - ecdsa !=0.15
+    - pyasn1
+    - python
+    - rsa
 
 test:
   files:
@@ -31,9 +34,11 @@ test:
   source_files:
     - tests
   commands:
+    - pip check
     - python usage.py
     - pytest -m "not (pycryptodome or pycrypto or backend_compatibility)" tests
   requires:
+    - pip
     - pytest
   imports:
     - jose

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
https://github.com/conda-forge/celery-feedstock/pull/53#issuecomment-863268973 fails as some dependencies are missing. Admittedly they're unused due to the presence of cryptography however `pip check` should still pass to prevent downstream failures. The alternative would be to patch the `setup.py` however I think that's a worse solution given it's likely to conflict and need updating each time a release is made.